### PR TITLE
Add Prompt to ProvidedOktaConfigModel

### DIFF
--- a/Example/Example/App/Authentication/AuthenticationView.swift
+++ b/Example/Example/App/Authentication/AuthenticationView.swift
@@ -23,7 +23,8 @@ class AuthenticationView: UIViewController {
             logoutRedirectUri: "",
             issuer: "",
             redirectUri: "",
-            scopes: "openid profile offline_access email"
+            scopes: "openid profile offline_access email",
+            prompt: nil,
         ))
         
         super.init(nibName: String(describing: AuthenticationView.self), bundle: nil)

--- a/Example/Example/App/Authentication/AuthenticationView.swift
+++ b/Example/Example/App/Authentication/AuthenticationView.swift
@@ -24,7 +24,7 @@ class AuthenticationView: UIViewController {
             issuer: "",
             redirectUri: "",
             scopes: "openid profile offline_access email",
-            prompt: nil,
+            prompt: "login",
         ))
         
         super.init(nibName: String(describing: AuthenticationView.self), bundle: nil)

--- a/Sources/OktaAuthentication/MinimumOktaConfigAttributes.swift
+++ b/Sources/OktaAuthentication/MinimumOktaConfigAttributes.swift
@@ -15,6 +15,7 @@ public protocol MinimumOktaConfigAttributes {
     var issuer: String { get }
     var redirectUri: String { get }
     var scopes: String { get }
+    var prompt: String? { get }
 }
 
 extension MinimumOktaConfigAttributes {
@@ -26,7 +27,8 @@ extension MinimumOktaConfigAttributes {
             "clientId": clientId,
             "logoutRedirectUri": logoutRedirectUri,
             "redirectUri": redirectUri,
-            "scopes": scopes
+            "scopes": scopes,
+            "prompt": prompt
         ]
         
         return data

--- a/Sources/OktaAuthentication/ProvidedOktaConfigModel.swift
+++ b/Sources/OktaAuthentication/ProvidedOktaConfigModel.swift
@@ -23,7 +23,7 @@ public struct ProvidedOktaConfigModel: OktaConfigModelType, MinimumOktaConfigAtt
         self.logoutRedirectUri = logoutRedirectUri
         self.issuer = issuer
         self.redirectUri = redirectUri
-        self.scopes = scopes'
+        self.scopes = scopes
         self.prompt = prompt
     }
     

--- a/Sources/OktaAuthentication/ProvidedOktaConfigModel.swift
+++ b/Sources/OktaAuthentication/ProvidedOktaConfigModel.swift
@@ -15,14 +15,16 @@ public struct ProvidedOktaConfigModel: OktaConfigModelType, MinimumOktaConfigAtt
     public let issuer: String
     public let redirectUri: String
     public let scopes: String
+    public let prompt: String?
     
-    public init(clientId: String, logoutRedirectUri: String, issuer: String, redirectUri: String, scopes: String) {
+    public init(clientId: String, logoutRedirectUri: String, issuer: String, redirectUri: String, scopes: String, prompt: String?) {
         
         self.clientId = clientId
         self.logoutRedirectUri = logoutRedirectUri
         self.issuer = issuer
         self.redirectUri = redirectUri
-        self.scopes = scopes
+        self.scopes = scopes'
+        self.prompt = prompt
     }
     
     public func getEncodedData() -> [String : String] {


### PR DESCRIPTION
`prompt` parameter allows us to control the behavior when a user is directed to Okta.

https://developer.okta.com/docs/reference/api/oidc/#parameter-details