### PR TITLE
Add Initializer for Default Prompt

### DIFF
--- a/Sources/OktaAuthentication/ProvidedOktaConfigModel.swift
+++ b/Sources/OktaAuthentication/ProvidedOktaConfigModel.swift
@@ -17,6 +17,16 @@ public struct ProvidedOktaConfigModel: OktaConfigModelType, MinimumOktaConfigAtt
     public let scopes: String
     public let prompt: String?
     
+    public init(clientId: String, logoutRedirectUri: String, issuer: String, redirectUri: String, scopes: String) {
+        
+        self.clientId = clientId
+        self.logoutRedirectUri = logoutRedirectUri
+        self.issuer = issuer
+        self.redirectUri = redirectUri
+        self.scopes = scopes
+        self.prompt = "login"
+    }
+
     public init(clientId: String, logoutRedirectUri: String, issuer: String, redirectUri: String, scopes: String, prompt: String?) {
         
         self.clientId = clientId


### PR DESCRIPTION
This adds another initializer for ProvidedOktaConfigModal, which does not require `prompt` to be passed in.  This helps us to have a default value for `prompt` and not needing to specify it.