### PR TITLE
Okta-Auth-iOS Remove refresh token if renew access token fails

### DIFF
--- a/OktaAuthentication.podspec
+++ b/OktaAuthentication.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
     s.name             = 'OktaAuthentication'
-    s.version          = '1.2.2'
+    s.version          = '1.2.3'
     s.summary          = 'Operates on OktaOidc and contains shared logic for Cru apps to authenticate with Okta.'
   
   

--- a/Sources/OktaAuthentication/CruOktaAuthentication/CruOktaAuthentication.swift
+++ b/Sources/OktaAuthentication/CruOktaAuthentication/CruOktaAuthentication.swift
@@ -31,6 +31,36 @@ public class CruOktaAuthentication: OktaAuthentication {
     
     public func signIn(fromViewController: UIViewController, completion: @escaping ((_ result: Result<OktaAccessToken, OktaAuthenticationError>, _ authMethodType: OktaAuthMethodType) -> Void)) {
         
+        var numberOfSignInRetries: Int = 0
+        
+        super.renewAccessTokenElseAuthenticate(fromViewController: fromViewController) { [weak self] (result: Result<OktaAccessToken, OktaAuthenticationError>, authMethodType: OktaAuthMethodType) in
+            
+            switch result {
+           
+            case .success( _):
+                break
+            
+            case .failure( _):
+                
+                let shouldSignOutAndAttemptNewSignIn: Bool = authMethodType == .renewedAccessToken && numberOfSignInRetries < 1
+                
+                guard !shouldSignOutAndAttemptNewSignIn else {
+                    
+                    numberOfSignInRetries += 1
+                    
+                    self?.removeSecureStorageAndRevokeStateManager(completion: { [weak self] (removeFromSecureStorageError: Error?, revokeError: Error?) in
+                        
+                        self?.renewAccessTokenElseAuthenticate(fromViewController: fromViewController, completion: completion)
+                    })
+                    
+                    return
+                }
+            }
+            
+            
+            completion(result, authMethodType)
+        }
+        
         super.renewAccessTokenElseAuthenticate(fromViewController: fromViewController, completion: completion)
     }
     

--- a/Sources/OktaAuthentication/CruOktaAuthentication/CruOktaAuthentication.swift
+++ b/Sources/OktaAuthentication/CruOktaAuthentication/CruOktaAuthentication.swift
@@ -59,9 +59,7 @@ public class CruOktaAuthentication: OktaAuthentication {
             
             
             completion(result, authMethodType)
-        }
-        
-        super.renewAccessTokenElseAuthenticate(fromViewController: fromViewController, completion: completion)
+        }        
     }
     
     public func signOut(fromViewController: UIViewController, completion: @escaping ((_ signOutError: OktaAuthenticationError?, _ removeFromSecureStorageError: Error?, _ revokeError: Error?) -> Void)) {


### PR DESCRIPTION
If renew access token fails, remove the persisted refresh token and attempt to sign in again.