### PR TITLE
Implement combine in shared OktaAuthentication for Cru apps

### DIFF
--- a/OktaAuthentication.podspec
+++ b/OktaAuthentication.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   
     s.swift_version = '5.5'
     s.platforms = {
-        "ios": "11.0"
+        "ios": "13.0"
     }
   
     s.source_files = 'Sources/**/*.{swift}'

--- a/OktaAuthentication.podspec
+++ b/OktaAuthentication.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
     s.name             = 'OktaAuthentication'
-    s.version          = '1.2.3'
+    s.version          = '1.3.0'
     s.summary          = 'Operates on OktaOidc and contains shared logic for Cru apps to authenticate with Okta.'
   
   

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "OktaAuthentication",
-    platforms: [.iOS(.v11)],
+    platforms: [.iOS(.v13)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Sources/OktaAuthentication/CruOktaAuthentication/CruOktaAuthentication+Combine.swift
+++ b/Sources/OktaAuthentication/CruOktaAuthentication/CruOktaAuthentication+Combine.swift
@@ -1,0 +1,56 @@
+//
+//  CruOktaAuthentication+Combine.swift
+//  OktaAuthentication
+//
+//  Created by Levi Eggert on 09/27/22.
+//  Copyright © 2022 Cru Global, Inc. All rights reserved.
+//
+
+import UIKit
+import Combine
+
+extension CruOktaAuthentication {
+    
+    public func signInPublisher(fromViewController: UIViewController) -> AnyPublisher<OktaAuthenticationResponse, Never> {
+        
+        return Future() { promise in
+            
+            self.signIn(fromViewController: fromViewController) { (response: OktaAuthenticationResponse) in
+                
+                promise(.success(response))
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+    
+    public func signOutPublisher(fromViewController: UIViewController) -> AnyPublisher<OktaSignOutResponse, Never> {
+        
+        return Future() { promise in
+            
+            self.signOut(fromViewController: fromViewController) { (signOutResponse: OktaSignOutResponse) in
+                
+                promise(.success(signOutResponse))
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+    
+    public func getAuthorizedCruUserPublisher() -> AnyPublisher<CruOktaUser, OktaAuthenticationError> {
+        
+        return Future() { promise in
+            
+            self.getAuthorizedCodableUser { (result: Result<CruOktaUser, OktaAuthenticationError>) in
+                
+                switch result {
+                    
+                case .success(let cruOktaUser):
+                    promise(.success(cruOktaUser))
+                    
+                case .failure(let oktaAuthenticationError):
+                    promise(.failure(oktaAuthenticationError))
+                }
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Sources/OktaAuthentication/OktaAuthentication/OktaAuthentication+Combine.swift
+++ b/Sources/OktaAuthentication/OktaAuthentication/OktaAuthentication+Combine.swift
@@ -1,0 +1,111 @@
+//
+//  OktaAuthentication+Combine.swift
+//  OktaAuthentication
+//
+//  Created by Levi Eggert on 09/27/22.
+//  Copyright © 2022 Cru Global, Inc. All rights reserved.
+//
+
+import UIKit
+import Combine
+
+extension OktaAuthentication {
+    
+    public func renewAccessTokenElseAuthenticatePublisher(fromViewController: UIViewController) -> AnyPublisher<OktaAuthenticationResponse, Never> {
+        
+        return Future() { promise in
+                
+            self.renewAccessTokenElseAuthenticate(fromViewController: fromViewController) { (response: OktaAuthenticationResponse) in
+                
+                promise(.success(response))
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+    
+    public func authenticatePublisher(fromViewController: UIViewController) -> AnyPublisher<OktaAuthenticationResponse, Never> {
+        
+        return Future() { promise in
+                
+            self.authenticate(fromViewController: fromViewController) { (response: OktaAuthenticationResponse) in
+                
+                promise(.success(response))
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+    
+    public func renewAccessTokenPublisher() -> AnyPublisher<OktaAuthenticationResponse, Never> {
+        
+        return Future() { promise in
+            
+            self.renewAccessToken { (response: OktaAuthenticationResponse) in
+                
+                promise(.success(response))
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+    
+    public func signOutPublisher(fromViewController: UIViewController, forceRemoveSecureStorageAndRevokeStateManager: Bool = false) -> AnyPublisher<OktaSignOutResponse, Never> {
+        
+        return Future() { promise in
+            
+            self.signOut(fromViewController: fromViewController, forceRemoveSecureStorageAndRevokeStateManager: forceRemoveSecureStorageAndRevokeStateManager) { (signOutResponse: OktaSignOutResponse) in
+                
+                promise(.success(signOutResponse))
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+    
+    public func removeSecureStorageAndRevokeStateManagerPublisher() -> AnyPublisher<OktaRevokeResponse, Never> {
+        
+        return Future() { promise in
+            
+            self.removeSecureStorageAndRevokeStateManager { (revokeResponse: OktaRevokeResponse) in
+                
+                promise(.success(revokeResponse))
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+    
+    public func getAuthorizedCodableUserPublisher<CodableUser: Codable>() -> AnyPublisher<CodableUser, OktaAuthenticationError> {
+        
+        return Future() { promise in
+            
+            self.getAuthorizedCodableUser { (result: Result<CodableUser, OktaAuthenticationError>) in
+                
+                switch result {
+                    
+                case .success(let codableUser):
+                    promise(.success(codableUser))
+                    
+                case .failure(let oktaAuthenticationError):
+                    promise(.failure(oktaAuthenticationError))
+                }
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+    
+    public func getAuthorizedUserJsonObjectPublisher() -> AnyPublisher<[String: Any], OktaAuthenticationError> {
+        
+        return Future() { promise in
+            
+            self.getAuthorizedUserJsonObject { (result: Result<[String: Any], OktaAuthenticationError>) in
+                
+                switch result {
+                    
+                case .success(let userObject):
+                    promise(.success(userObject))
+                    
+                case .failure(let oktaAuthenticationError):
+                    promise(.failure(oktaAuthenticationError))
+                }
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Sources/OktaAuthentication/OktaAuthentication/OktaAuthenticationResponse.swift
+++ b/Sources/OktaAuthentication/OktaAuthentication/OktaAuthenticationResponse.swift
@@ -1,0 +1,15 @@
+//
+//  OktaAuthenticationResponse.swift
+//  OktaAuthentication
+//
+//  Created by Levi Eggert on 09/27/22.
+//  Copyright © 2022 Cru Global, Inc. All rights reserved.
+//
+
+import Foundation
+
+public struct OktaAuthenticationResponse {
+    
+    public let result: Result<OktaAccessToken, OktaAuthenticationError>
+    public let authMethod: OktaAuthMethodType
+}

--- a/Sources/OktaAuthentication/OktaAuthentication/OktaRevokeResponse.swift
+++ b/Sources/OktaAuthentication/OktaAuthentication/OktaRevokeResponse.swift
@@ -1,0 +1,15 @@
+//
+//  OktaRevokeResponse.swift
+//  OktaAuthentication
+//
+//  Created by Levi Eggert on 09/27/22.
+//  Copyright © 2022 Cru Global, Inc. All rights reserved.
+//
+
+import Foundation
+
+public struct OktaRevokeResponse {
+    
+    public let removeFromSecureStorageError: Error?
+    public let revokeError: Error?
+}

--- a/Sources/OktaAuthentication/OktaAuthentication/OktaSignOutResponse.swift
+++ b/Sources/OktaAuthentication/OktaAuthentication/OktaSignOutResponse.swift
@@ -1,0 +1,16 @@
+//
+//  OktaSignOutResponse.swift
+//  OktaAuthentication
+//
+//  Created by Levi Eggert on 09/27/22.
+//  Copyright © 2022 Cru Global, Inc. All rights reserved.
+//
+
+import Foundation
+
+public struct OktaSignOutResponse {
+    
+    public let signOutError: OktaAuthenticationError?
+    public let revokeResponse: OktaRevokeResponse?
+}
+


### PR DESCRIPTION
This PR adds extensions for ```Combine Publishers```.

- Increased minimum deployment target to iOS 13.
- Added some structs to wrap the responses returned from OktaAuthentication.swift for Combine AnyPublishers.
- Added Combine extensions on OktaAuthentication and CruOktaAuthentication.