### PR TITLE
Implement new okta authentication method

### DIFF
--- a/OktaAuthentication.podspec
+++ b/OktaAuthentication.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
     s.name             = 'OktaAuthentication'
-    s.version          = '1.3.0'
+    s.version          = '1.4.0'
     s.summary          = 'Operates on OktaOidc and contains shared logic for Cru apps to authenticate with Okta.'
   
   

--- a/Sources/OktaAuthentication/CruOktaAuthentication/CruOktaAuthentication.swift
+++ b/Sources/OktaAuthentication/CruOktaAuthentication/CruOktaAuthentication.swift
@@ -13,7 +13,7 @@ public class CruOktaAuthentication: OktaAuthentication {
     private static let defaultScopes: String = "openid profile offline_access email"
     private static let defaultPrompt: String = "login"
     
-    public required init(clientId: String, logoutRedirectUri: String, issuer: String, redirectUri: String) {
+    public init(clientId: String, logoutRedirectUri: String, issuer: String, redirectUri: String) {
         
         super.init(configModel: OktaConfigModel(
             clientId: clientId,
@@ -23,10 +23,6 @@ public class CruOktaAuthentication: OktaAuthentication {
             redirectUri: redirectUri,
             scopes: CruOktaAuthentication.defaultScopes)
         )
-    }
-    
-    public required init(configModel: OktaConfigModelType) {
-        fatalError("init(configModel:) is not supported.")
     }
     
     public func signIn(fromViewController: UIViewController, completion: @escaping ((_ response: OktaAuthenticationResponse) -> Void)) {

--- a/Sources/OktaAuthentication/CruOktaAuthentication/CruOktaAuthentication.swift
+++ b/Sources/OktaAuthentication/CruOktaAuthentication/CruOktaAuthentication.swift
@@ -27,34 +27,7 @@ public class CruOktaAuthentication: OktaAuthentication {
     
     public func signIn(fromViewController: UIViewController, completion: @escaping ((_ response: OktaAuthenticationResponse) -> Void)) {
         
-        var numberOfSignInRetries: Int = 0
-        
-        super.renewAccessTokenElseAuthenticate(fromViewController: fromViewController) { [weak self] (response: OktaAuthenticationResponse) in
-            
-            switch response.result {
-           
-            case .success( _):
-                break
-            
-            case .failure( _):
-                
-                let shouldSignOutAndAttemptNewSignIn: Bool = response.authMethod == .renewedAccessToken && numberOfSignInRetries < 1
-                
-                guard !shouldSignOutAndAttemptNewSignIn else {
-                    
-                    numberOfSignInRetries += 1
-                    
-                    self?.removeSecureStorageAndRevokeStateManager(completion: { [weak self] (revokeResponse: OktaRevokeResponse) in
-                        
-                        self?.renewAccessTokenElseAuthenticate(fromViewController: fromViewController, completion: completion)
-                    })
-                    
-                    return
-                }
-            }
-            
-            completion(response)
-        }        
+        super.authenticate(fromViewController: fromViewController, policy: .attemptToRenewAccessTokenElseSignInWithBrowser(shouldSignOutAndRetryAuthenticationIfAuthenticationFails: true), completion: completion)
     }
     
     public func signOut(fromViewController: UIViewController, completion: @escaping ((_ signOutResponse: OktaSignOutResponse) -> Void)) {

--- a/Sources/OktaAuthentication/OktaAuthentication/OktaAuthentication+Combine.swift
+++ b/Sources/OktaAuthentication/OktaAuthentication/OktaAuthentication+Combine.swift
@@ -11,23 +11,11 @@ import Combine
 
 extension OktaAuthentication {
     
-    public func renewAccessTokenElseAuthenticatePublisher(fromViewController: UIViewController) -> AnyPublisher<OktaAuthenticationResponse, Never> {
+    public func authenticatePublisher(fromViewController: UIViewController, policy: OktaAuthenticationPolicy) -> AnyPublisher<OktaAuthenticationResponse, Never> {
         
         return Future() { promise in
                 
-            self.renewAccessTokenElseAuthenticate(fromViewController: fromViewController) { (response: OktaAuthenticationResponse) in
-                
-                promise(.success(response))
-            }
-        }
-        .eraseToAnyPublisher()
-    }
-    
-    public func authenticatePublisher(fromViewController: UIViewController) -> AnyPublisher<OktaAuthenticationResponse, Never> {
-        
-        return Future() { promise in
-                
-            self.authenticate(fromViewController: fromViewController) { (response: OktaAuthenticationResponse) in
+            self.authenticate(fromViewController: fromViewController, policy: policy) { (response: OktaAuthenticationResponse) in
                 
                 promise(.success(response))
             }

--- a/Sources/OktaAuthentication/OktaAuthentication/OktaAuthentication.swift
+++ b/Sources/OktaAuthentication/OktaAuthentication/OktaAuthentication.swift
@@ -16,7 +16,7 @@ public class OktaAuthentication {
     
     private let oktaOidc: OktaOidc?
             
-    public required init(configModel: OktaConfigModelType) {
+    public init(configModel: OktaConfigModelType) {
         
         let configData: [String: String] = configModel.getEncodedData()
         

--- a/Sources/OktaAuthentication/OktaAuthentication/OktaAuthenticationPolicy.swift
+++ b/Sources/OktaAuthentication/OktaAuthentication/OktaAuthenticationPolicy.swift
@@ -1,0 +1,15 @@
+//
+//  OktaAuthenticationPolicy.swift
+//  OktaAuthentication
+//
+//  Created by Levi Eggert on 2/24/23.
+//  Copyright © 2023 Cru Global, Inc. All rights reserved.
+//
+
+import Foundation
+
+public enum OktaAuthenticationPolicy {
+    
+    case attemptToRenewAccessTokenElseSignInWithBrowser(shouldSignOutAndRetryAuthenticationIfAuthenticationFails: Bool)
+    case signInWithBrowser
+}


### PR DESCRIPTION
This PR implements a single authentication point on OktaAuthentication with supported auth policy:
```case attemptToRenewAccessTokenElseSignInWithBrowser(shouldSignOutAndRetryAuthenticationIfAuthenticationFails: Bool)```
```case signInWithBrowser```

These contain helper logic with renewing stored access tokens and re-attempting authentication.